### PR TITLE
Add search helpers and basic UI methods

### DIFF
--- a/travelagency.cpp
+++ b/travelagency.cpp
@@ -322,3 +322,21 @@ void TravelAgency::editBooking(const QString &id)
 
     qDebug() << "Keine Buchung mit ID" << id << "gefunden.";
 }
+
+Customer *TravelAgency::findCustomerById(const QString &id) const
+{
+    for (Customer *c : allCustomers) {
+        if (c->getId() == id)
+            return c;
+    }
+    return nullptr;
+}
+
+Travel *TravelAgency::findTravelById(const QString &id) const
+{
+    for (Travel *t : allTravels) {
+        if (t->getId() == id)
+            return t;
+    }
+    return nullptr;
+}

--- a/travelagency.h
+++ b/travelagency.h
@@ -25,6 +25,8 @@ public:
     void printStatistics() const;
     void reset();
     void editBooking(const QString &id);
+    Customer *findCustomerById(const QString &id) const;
+    Travel *findTravelById(const QString &id) const;
     const std::vector<Booking *> &getBookings() const;
     QVector<Travel *> getAllTravels() const { return allTravels; };
     QVector<Customer *> getAllCustomers() const { return allCustomers; };

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -18,6 +18,8 @@ TravelAgencyUI::TravelAgencyUI(TravelAgency *agency, QWidget *parent)
     , agency(agency)
 {
     ui->setupUi(this);
+    setupUI();
+    setupMenuAndToolbar();
 
     connect(ui->actionDateiOeffnen,
             &QAction::triggered,
@@ -121,4 +123,68 @@ void TravelAgencyUI::zeigeReisenDesKunden(Customer *kunde)
     }
 
     ui->reiseTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+}
+
+void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *)
+{
+    // Placeholder for future implementation
+}
+
+void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
+{
+    if (!item)
+        return;
+
+    QString travelId = item->text();
+    Travel *travel = agency->findTravelById(travelId);
+    if (!travel)
+        return;
+
+    BookingDetailDialog dlg(this);
+    if (!travel->getTravelBookings().empty()) {
+        dlg.setBooking(travel->getTravelBookings().front());
+    }
+    dlg.exec();
+}
+
+void TravelAgencyUI::setupUI()
+{
+    // ensure tables have no edit triggers by default
+    if (ui->customerTable)
+        ui->customerTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    if (ui->reiseTable)
+        ui->reiseTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+}
+
+void TravelAgencyUI::setupMenuAndToolbar()
+{
+    // placeholder: no additional setup needed
+}
+
+void TravelAgencyUI::clearTables()
+{
+    if (ui->customerTable)
+        ui->customerTable->clearContents();
+    if (ui->reiseTable)
+        ui->reiseTable->clearContents();
+}
+
+void TravelAgencyUI::showCustomerInfo(Customer *customer)
+{
+    if (!customer)
+        return;
+    ui->lineEditCustomerId->setText(customer->getId());
+    ui->lineEditFirstName->setText(customer->getFirstName());
+    ui->lineEditLastName->setText(customer->getLastName());
+}
+
+void TravelAgencyUI::showTravelDetails(Travel *travel)
+{
+    if (!travel)
+        return;
+    // currently only showing first booking in dialog
+    BookingDetailDialog dlg(this);
+    if (!travel->getTravelBookings().empty())
+        dlg.setBooking(travel->getTravelBookings().front());
+    dlg.exec();
 }

--- a/travelagencyui.h
+++ b/travelagencyui.h
@@ -64,7 +64,7 @@ private:
 
 private slots:
     void on_actionDateiOeffnenClicked();
-    void onSearchCustomerClicked();
+    void on_actionEintragssucheClicked();
     void onCustomerTableDoubleClicked(QTableWidgetItem *item);
     void onTravelTableDoubleClicked(QTableWidgetItem *item);
 };

--- a/travelagencyui.ui
+++ b/travelagencyui.ui
@@ -34,6 +34,36 @@
      </rect>
     </property>
    </widget>
+   <widget class="QLineEdit" name="lineEditCustomerId">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>113</width>
+      <height>28</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="lineEditFirstName">
+    <property name="geometry">
+     <rect>
+      <x>150</x>
+      <y>20</y>
+      <width>113</width>
+      <height>28</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLineEdit" name="lineEditLastName">
+    <property name="geometry">
+     <rect>
+      <x>280</x>
+      <y>20</y>
+      <width>113</width>
+      <height>28</height>
+     </rect>
+    </property>
+   </widget>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QMenuBar" name="menuBar">


### PR DESCRIPTION
## Summary
- implement helper functions to find customers and travels
- stub out various TravelAgencyUI helper methods and connect them
- add minimal line edits to the UI for customer info display

## Testing
- `cmake ..` *(fails: Qt not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68488e1439a08321a1fbc91a564e8357