### PR TITLE
Fix merge artifacts in TravelAgencyUI

### DIFF
--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -201,13 +201,7 @@ void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *item)
     BookingDetailDialog dlg(this);
     dlg.setBooking(booking);
     dlg.exec();
-=======
-void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *)
-{
-    // Placeholder for future implementation
-
 }
-
 void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
 {
     if (!item)
@@ -215,7 +209,6 @@ void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
     int row = item->row();
     QString travelId = ui->reiseTable->item(row, 0)->text();
 
-    QString travelId = item->text();
 
     Travel *travel = agency->findTravelById(travelId);
     if (!travel)


### PR DESCRIPTION
## Summary
- resolve leftover merge markers in TravelAgencyUI
- remove duplicate travelId variable
- close onCustomerTableDoubleClicked function correctly

## Testing
- `cmake -S . -B buildtest` *(fails: Could not find package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6848a76fe398832183021edf9d3801e1