### PR TITLE
Improve booking detail dialog and travel interactions

### DIFF
--- a/bookingdialog.cpp
+++ b/bookingdialog.cpp
@@ -36,6 +36,27 @@ void BookingDetailDialog::setBooking(Booking *booking)
         ui->lineEditExtra2->setText(train->getToStation());
 
         ui->listWidgetDetails->clear();
+
+        // translate booking class codes to human readable form
+        const QString &classCode = train->getBookingClass();
+        QString classDesc;
+        if (classCode == "SSP1")
+            classDesc = "Supersparpreis 1. Klasse";
+        else if (classCode == "SSP2")
+            classDesc = "Supersparpreis 2. Klasse";
+        else if (classCode == "SP1")
+            classDesc = "Sparpreis 1. Klasse";
+        else if (classCode == "SP2")
+            classDesc = "Sparpreis 2. Klasse";
+        else if (classCode == "FP1")
+            classDesc = "Flexpreis 1. Klasse";
+        else if (classCode == "FP2")
+            classDesc = "Flexpreis 2. Klasse";
+        else
+            classDesc = classCode;
+
+        ui->listWidgetDetails->addItem("Buchungsklasse: " + classDesc);
+
         for (const auto &stop : train->getStops()) {
             ui->listWidgetDetails->addItem(stop);
         }
@@ -49,6 +70,21 @@ void BookingDetailDialog::setBooking(Booking *booking)
         ui->listWidgetDetails->clear();
         ui->listWidgetDetails->addItem("Airline: " + flight->getAirline());
 
+        QString classDesc;
+        const QString &classCode = flight->getBookingClass();
+        if (classCode == "Y")
+            classDesc = "Economy";
+        else if (classCode == "W")
+            classDesc = "Premium Economy";
+        else if (classCode == "J")
+            classDesc = "Business";
+        else if (classCode == "F")
+            classDesc = "First";
+        else
+            classDesc = classCode;
+
+        ui->listWidgetDetails->addItem("Buchungsklasse: " + classDesc);
+
     } else if (auto *hotel = dynamic_cast<HotelBooking *>(booking)) {
         ui->lineEditExtra1->setPlaceholderText("Hotel");
         ui->lineEditExtra1->setText(hotel->getHotel());
@@ -56,6 +92,21 @@ void BookingDetailDialog::setBooking(Booking *booking)
         ui->lineEditExtra2->setText(hotel->getTown());
 
         ui->listWidgetDetails->clear();
+
+        QString roomDesc;
+        const QString &roomType = hotel->getRoomType();
+        if (roomType == "EZ")
+            roomDesc = "Einzelzimmer";
+        else if (roomType == "DZ")
+            roomDesc = "Doppelzimmer";
+        else if (roomType == "SU")
+            roomDesc = "Suite";
+        else if (roomType == "AP")
+            roomDesc = "Appartment";
+        else
+            roomDesc = roomType;
+
+        ui->listWidgetDetails->addItem("Zimmerkategorie: " + roomDesc);
 
     } else if (auto *car = dynamic_cast<RentalCarReservation *>(booking)) {
         ui->lineEditExtra1->setPlaceholderText("Abholung");

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -201,13 +201,7 @@ void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *item)
     BookingDetailDialog dlg(this);
     dlg.setBooking(booking);
     dlg.exec();
-=======
-void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *)
-{
-    // Placeholder for future implementation
-
 }
-
 void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
 {
     if (!item)
@@ -215,7 +209,6 @@ void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
     int row = item->row();
     QString travelId = ui->reiseTable->item(row, 0)->text();
 
-    QString travelId = item->text();
 
     Travel *travel = agency->findTravelById(travelId);
     if (!travel)
@@ -223,12 +216,6 @@ void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)
 
 
     zeigeBuchungenZurReise(travel);
-
-    BookingDetailDialog dlg(this);
-    if (!travel->getTravelBookings().empty()) {
-        dlg.setBooking(travel->getTravelBookings().front());
-    }
-    dlg.exec();
 
 }
 


### PR DESCRIPTION
## Summary
- translate booking classes for trains, flights and hotels in booking dialog
- show booking class or room description in detail view
- only open booking details when double-clicking a booking, not a travel

## Testing
- `cmake -S . -B buildtest` *(fails: Could not find package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6848a76fe398832183021edf9d3801e1