### PR TITLE
Extend bookings with GPS coordinates

### DIFF
--- a/flightbooking.cpp
+++ b/flightbooking.cpp
@@ -8,12 +8,20 @@ FlightBooking::FlightBooking(QString id,
                              QString fromDest,
                              QString toDest,
                              QString airline,
-                             QString bookingClass)
+                             QString bookingClass,
+                             double fromLatitude,
+                             double fromLongitude,
+                             double toLatitude,
+                             double toLongitude)
     : Booking(id, price, fromDate, toDate)
     , fromDest(fromDest)
     , toDest(toDest)
     , airline(airline)
     , bookingClass(bookingClass)
+    , fromLatitude(fromLatitude)
+    , fromLongitude(fromLongitude)
+    , toLatitude(toLatitude)
+    , toLongitude(toLongitude)
 {}
 
 // Startflughafen

--- a/flightbooking.h
+++ b/flightbooking.h
@@ -11,6 +11,10 @@ private:
     QString toDest;
     QString airline;
     QString bookingClass;
+    double fromLatitude = 0.0;
+    double fromLongitude = 0.0;
+    double toLatitude = 0.0;
+    double toLongitude = 0.0;
 
 public:
     FlightBooking(QString id,
@@ -20,12 +24,20 @@ public:
                   QString fromDest,
                   QString toDest,
                   QString airline,
-                  QString bookingClass);
+                  QString bookingClass,
+                  double fromLatitude = 0.0,
+                  double fromLongitude = 0.0,
+                  double toLatitude = 0.0,
+                  double toLongitude = 0.0);
 
     QString getFromDest() const;
     QString getToDest() const;
     QString getAirline() const;
     QString getBookingClass() const;
+    double getFromLatitude() const { return fromLatitude; }
+    double getFromLongitude() const { return fromLongitude; }
+    double getToLatitude() const { return toLatitude; }
+    double getToLongitude() const { return toLongitude; }
     void setFromDest(const QString &dest);
     void setToDest(const QString &dest);
     void setAirline(const QString &airline);

--- a/hotelbooking.cpp
+++ b/hotelbooking.cpp
@@ -7,11 +7,15 @@ HotelBooking::HotelBooking(const QString &id,
                            const QDate &toDate,
                            const QString &hotel,
                            const QString &town,
-                           const QString &roomType)
+                           const QString &roomType,
+                           double latitude,
+                           double longitude)
     : Booking(id, price, fromDate, toDate)
     , hotel(hotel)
     , town(town)
     , roomType(roomType)
+    , latitude(latitude)
+    , longitude(longitude)
 {}
 
 // Name des Hotels

--- a/hotelbooking.h
+++ b/hotelbooking.h
@@ -9,6 +9,8 @@ private:
     QString hotel;
     QString town;
     QString roomType;
+    double latitude = 0.0;
+    double longitude = 0.0;
 
 public:
     HotelBooking(const QString &id,
@@ -17,11 +19,15 @@ public:
                  const QDate &toDate,
                  const QString &hotel,
                  const QString &town,
-                 const QString &roomType);
+                 const QString &roomType,
+                 double latitude = 0.0,
+                 double longitude = 0.0);
 
     QString getHotel() const;
     QString getTown() const;
     QString getRoomType() const;
+    double getLatitude() const { return latitude; }
+    double getLongitude() const { return longitude; }
     void setHotel(const QString &h);
     void setTown(const QString &t);
     void setRoomType(const QString &rt);

--- a/rentalcarreservation.cpp
+++ b/rentalcarreservation.cpp
@@ -8,12 +8,20 @@ RentalCarReservation::RentalCarReservation(QString id,
                                            const QString &pickupLocation,
                                            const QString &returnLocation,
                                            const QString &company,
-                                           const QString &carType)
+                                           const QString &carType,
+                                           double pickupLatitude,
+                                           double pickupLongitude,
+                                           double returnLatitude,
+                                           double returnLongitude)
     : Booking(id, price, fromDate, toDate)
     , pickupLocation(pickupLocation)
     , returnLocation(returnLocation)
     , company(company)
     , carType(carType)
+    , pickupLatitude(pickupLatitude)
+    , pickupLongitude(pickupLongitude)
+    , returnLatitude(returnLatitude)
+    , returnLongitude(returnLongitude)
 {}
 
 // Ort der Abholung

--- a/rentalcarreservation.h
+++ b/rentalcarreservation.h
@@ -11,6 +11,10 @@ private:
     QString returnLocation;
     QString company;
     QString carType;
+    double pickupLatitude = 0.0;
+    double pickupLongitude = 0.0;
+    double returnLatitude = 0.0;
+    double returnLongitude = 0.0;
 
 public:
     RentalCarReservation(QString id,
@@ -20,12 +24,20 @@ public:
                          const QString &pickupLocation,
                          const QString &returnLocation,
                          const QString &company,
-                         const QString &carType);
+                         const QString &carType,
+                         double pickupLatitude = 0.0,
+                         double pickupLongitude = 0.0,
+                         double returnLatitude = 0.0,
+                         double returnLongitude = 0.0);
 
     QString getPickupLocation() const;
     QString getReturnLocation() const;
     QString getCompany() const;
     QString getCarType() const;
+    double getPickupLatitude() const { return pickupLatitude; }
+    double getPickupLongitude() const { return pickupLongitude; }
+    double getReturnLatitude() const { return returnLatitude; }
+    double getReturnLongitude() const { return returnLongitude; }
     void setPickupLocation(const QString &loc);
     void setReturnLocation(const QString &loc);
     void setCompany(const QString &c);

--- a/trainticket.cpp
+++ b/trainticket.cpp
@@ -10,7 +10,11 @@ TrainTicket::TrainTicket(QString id,
                          const QString &departureTime,
                          const QString &arrivalTime,
                          const QString &bookingClass,
-                         const QVector<QString> &stops)
+                         const QVector<QString> &stops,
+                         double fromLatitude,
+                         double fromLongitude,
+                         double toLatitude,
+                         double toLongitude)
     : Booking(id, price, fromDate, toDate)
     , fromStation(fromStation)
     , toStation(toStation)
@@ -18,6 +22,10 @@ TrainTicket::TrainTicket(QString id,
     , arrivalTime(arrivalTime)
     , bookingClass(bookingClass)
     , stops(stops)
+    , fromLatitude(fromLatitude)
+    , fromLongitude(fromLongitude)
+    , toLatitude(toLatitude)
+    , toLongitude(toLongitude)
 {}
 
 // Startbahnhof

--- a/trainticket.h
+++ b/trainticket.h
@@ -14,6 +14,10 @@ private:
     QString arrivalTime;
     QString bookingClass;
     QVector<QString> stops;
+    double fromLatitude = 0.0;
+    double fromLongitude = 0.0;
+    double toLatitude = 0.0;
+    double toLongitude = 0.0;
 
 public:
     TrainTicket(QString id,
@@ -25,7 +29,11 @@ public:
                 const QString &departureTime,
                 const QString &arrivalTime,
                 const QString &bookingClass,
-                const QVector<QString> &stops);
+                const QVector<QString> &stops,
+                double fromLatitude = 0.0,
+                double fromLongitude = 0.0,
+                double toLatitude = 0.0,
+                double toLongitude = 0.0);
 
     QString getFromStation() const;
     QString getToStation() const;
@@ -33,6 +41,10 @@ public:
     QString getArrivalTime() const;
     QString getBookingClass() const;
     QVector<QString> getStops() const;
+    double getFromLatitude() const { return fromLatitude; }
+    double getFromLongitude() const { return fromLongitude; }
+    double getToLatitude() const { return toLatitude; }
+    double getToLongitude() const { return toLongitude; }
     void setFromStation(const QString &from);
     void setToStation(const QString &to);
     void setDepartureTime(const QString &t);

--- a/travelagency.cpp
+++ b/travelagency.cpp
@@ -139,6 +139,10 @@ void TravelAgency::readFile(const std::string &filename)
                 QString bookingClass = entry.contains("bookingClass")
                                            ? QString::fromStdString(entry["bookingClass"])
                                            : "Y";
+                double fromLat = entry.contains("fromDestLatitude") ? entry["fromDestLatitude"].get<double>() : 0.0;
+                double fromLon = entry.contains("fromDestLongitude") ? entry["fromDestLongitude"].get<double>() : 0.0;
+                double toLat = entry.contains("toDestLatitude") ? entry["toDestLatitude"].get<double>() : 0.0;
+                double toLon = entry.contains("toDestLongitude") ? entry["toDestLongitude"].get<double>() : 0.0;
                 booking = new FlightBooking(bookingId,
                                             price,
                                             fromDate,
@@ -146,7 +150,11 @@ void TravelAgency::readFile(const std::string &filename)
                                             fromDest,
                                             toDest,
                                             airline,
-                                            bookingClass);
+                                            bookingClass,
+                                            fromLat,
+                                            fromLon,
+                                            toLat,
+                                            toLon);
 
             } else if (type == "Hotel") {
                 QString hotel = QString::fromStdString(entry["hotel"]);
@@ -154,7 +162,9 @@ void TravelAgency::readFile(const std::string &filename)
                 QString roomType = entry.contains("roomType")
                                        ? QString::fromStdString(entry["roomType"])
                                        : "Standard";
-                booking = new HotelBooking(bookingId, price, fromDate, toDate, hotel, town, roomType);
+                double lat = entry.contains("latitude") ? entry["latitude"].get<double>() : 0.0;
+                double lon = entry.contains("longitude") ? entry["longitude"].get<double>() : 0.0;
+                booking = new HotelBooking(bookingId, price, fromDate, toDate, hotel, town, roomType, lat, lon);
 
             } else if (type == "Rental" || type == "RentalCar") {
                 QString pickup = QString::fromStdString(entry["pickupLocation"]);
@@ -167,6 +177,10 @@ void TravelAgency::readFile(const std::string &filename)
                     carType = QString::fromStdString(entry["vehicleClass"]);
                 else
                     carType = "Standard";
+                double pickupLat = entry.contains("pickupLatitude") ? entry["pickupLatitude"].get<double>() : 0.0;
+                double pickupLon = entry.contains("pickupLongitude") ? entry["pickupLongitude"].get<double>() : 0.0;
+                double returnLat = entry.contains("returnLatitude") ? entry["returnLatitude"].get<double>() : 0.0;
+                double returnLon = entry.contains("returnLongitude") ? entry["returnLongitude"].get<double>() : 0.0;
                 booking = new RentalCarReservation(bookingId,
                                                    price,
                                                    fromDate,
@@ -174,7 +188,11 @@ void TravelAgency::readFile(const std::string &filename)
                                                    pickup,
                                                    retLoc,
                                                    company,
-                                                   carType);
+                                                   carType,
+                                                   pickupLat,
+                                                   pickupLon,
+                                                   returnLat,
+                                                   returnLon);
 
             } else if (type == "Train") {
                 QString fromStation = QString::fromStdString(entry["fromStation"]);
@@ -199,6 +217,10 @@ void TravelAgency::readFile(const std::string &filename)
                         stops.append(QString::fromStdString(s));
                     }
                 }
+                double fromLat = entry.contains("fromStationLatitude") ? entry["fromStationLatitude"].get<double>() : 0.0;
+                double fromLon = entry.contains("fromStationLongitude") ? entry["fromStationLongitude"].get<double>() : 0.0;
+                double toLat = entry.contains("toStationLatitude") ? entry["toStationLatitude"].get<double>() : 0.0;
+                double toLon = entry.contains("toStationLongitude") ? entry["toStationLongitude"].get<double>() : 0.0;
                 booking = new TrainTicket(bookingId,
                                           price,
                                           fromDate,
@@ -208,7 +230,11 @@ void TravelAgency::readFile(const std::string &filename)
                                           depTime,
                                           arrTime,
                                           bookingClass,
-                                          stops);
+                                          stops,
+                                          fromLat,
+                                          fromLon,
+                                          toLat,
+                                          toLon);
             }
 
             if (booking) {
@@ -246,12 +272,18 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["toDest"] = fb->getToDest().toStdString();
             entry["airline"] = fb->getAirline().toStdString();
             entry["bookingClass"] = fb->getBookingClass().toStdString();
+            entry["fromDestLatitude"] = fb->getFromLatitude();
+            entry["fromDestLongitude"] = fb->getFromLongitude();
+            entry["toDestLatitude"] = fb->getToLatitude();
+            entry["toDestLongitude"] = fb->getToLongitude();
 
         } else if (const HotelBooking *hb = dynamic_cast<const HotelBooking *>(booking)) {
             entry["type"] = "Hotel";
             entry["hotel"] = hb->getHotel().toStdString();
             entry["town"] = hb->getTown().toStdString();
             entry["roomType"] = hb->getRoomType().toStdString();
+            entry["latitude"] = hb->getLatitude();
+            entry["longitude"] = hb->getLongitude();
 
         } else if (const RentalCarReservation *rc = dynamic_cast<const RentalCarReservation *>(
                        booking)) {
@@ -260,6 +292,10 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["returnLocation"] = rc->getReturnLocation().toStdString();
             entry["company"] = rc->getCompany().toStdString();
             entry["carType"] = rc->getCarType().toStdString();
+            entry["pickupLatitude"] = rc->getPickupLatitude();
+            entry["pickupLongitude"] = rc->getPickupLongitude();
+            entry["returnLatitude"] = rc->getReturnLatitude();
+            entry["returnLongitude"] = rc->getReturnLongitude();
 
         } else if (const TrainTicket *tt = dynamic_cast<const TrainTicket *>(booking)) {
             entry["type"] = "Train";
@@ -268,6 +304,10 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["departureTime"] = tt->getDepartureTime().toStdString();
             entry["arrivalTime"] = tt->getArrivalTime().toStdString();
             entry["bookingClass"] = tt->getBookingClass().toStdString();
+            entry["fromStationLatitude"] = tt->getFromLatitude();
+            entry["fromStationLongitude"] = tt->getFromLongitude();
+            entry["toStationLatitude"] = tt->getToLatitude();
+            entry["toStationLongitude"] = tt->getToLongitude();
 
             std::vector<std::string> stops;
             for (const QString &stop : tt->getStops()) {


### PR DESCRIPTION
## Summary
- add latitude and longitude properties for all booking location types
- parse optional GPS data from JSON when reading bookings
- persist GPS data when writing JSON

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_6856273322548321a6a7e1d49fcee7e8