### PR TITLE
Implement travel overlap check; remove QtWebEngine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets WebEngineWidgets)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets WebEngineWidgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
 set(PROJECT_SOURCES
   booking.h booking.cpp
@@ -57,7 +57,7 @@ else()
     endif()
 endif()
 
-target_link_libraries(Praktikum2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::WebEngineWidgets)
+target_link_libraries(Praktikum2 PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 
 # Qt for iOS sets MACOSX_BUNDLE_GUI_IDENTIFIER automatically since Qt 6.1.
 # If you are developing for iOS or macOS you should consider setting an

--- a/check.cpp
+++ b/check.cpp
@@ -1,15 +1,69 @@
 #include "check.h"
 #include "travelagency.h"
 #include <QDebug>
+#include "customer.h"
+#include "travel.h"
 
 Check::Check(std::shared_ptr<TravelAgency> agency)
     : agency(std::move(agency))
 {
 }
 
+bool Check::checkTravelsDisjunct(QString &errorMsg) const
+{
+    if (!agency)
+        return true;
+
+    for (const auto &customer : agency->getAllCustomers()) {
+        const auto &travels = customer->getTravelList();
+        for (int i = 0; i < travels.size(); ++i) {
+            const auto &t1 = travels[i];
+
+            QDate start1 = QDate(9999, 12, 31);
+            QDate end1 = QDate(1, 1, 1);
+            for (const auto &b : t1->getTravelBookings()) {
+                if (b->getFromDate() < start1)
+                    start1 = b->getFromDate();
+                if (b->getToDate() > end1)
+                    end1 = b->getToDate();
+            }
+
+            for (int j = i + 1; j < travels.size(); ++j) {
+                const auto &t2 = travels[j];
+
+                QDate start2 = QDate(9999, 12, 31);
+                QDate end2 = QDate(1, 1, 1);
+                for (const auto &b : t2->getTravelBookings()) {
+                    if (b->getFromDate() < start2)
+                        start2 = b->getFromDate();
+                    if (b->getToDate() > end2)
+                        end2 = b->getToDate();
+                }
+
+                if (start1 <= end2 && start2 <= end1) {
+                    errorMsg = QString("Reisen %1 und %2 von %3 %4 ueberschneiden sich")
+                                   .arg(t1->getId())
+                                   .arg(t2->getId())
+                                   .arg(customer->getFirstName())
+                                   .arg(customer->getLastName());
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
 void Check::performChecks() const
 {
     if (!agency)
         return;
+
+    QString error;
+    if (!checkTravelsDisjunct(error)) {
+        qWarning() << error;
+    }
+
     qDebug() << "Loaded bookings:" << agency->getBookings().size();
 }

--- a/check.h
+++ b/check.h
@@ -12,6 +12,7 @@ private:
 
 public:
     explicit Check(std::shared_ptr<TravelAgency> agency);
+    bool checkTravelsDisjunct(QString &errorMsg) const;
     void performChecks() const;
 };
 

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -31,9 +31,6 @@ TravelAgencyUI::TravelAgencyUI(std::shared_ptr<TravelAgency> agency,
     , agency(std::move(agency))
     , checker(std::move(checker))
 
-#include <QWebEngineView>
-#include "json.hpp"
-
 // Hauptfenster einrichten
 TravelAgencyUI::TravelAgencyUI(std::shared_ptr<TravelAgency> agency, QWidget *parent)
     : QMainWindow(parent)
@@ -330,15 +327,7 @@ void TravelAgencyUI::on_actionSpeichernTriggered()
 
 void TravelAgencyUI::updateMapForTravel(std::shared_ptr<Travel> travel)
 {
-
     if (!travel)
-
-
-    if (!travel)
-
-    if (!travel || !ui->webViewMap)
-
-
         return;
 
     using json = nlohmann::json;
@@ -405,29 +394,6 @@ void TravelAgencyUI::updateMapForTravel(std::shared_ptr<Travel> travel)
     QUrl url(QStringLiteral("https://geojson.io/#data=data:application/json,%1")
                  .arg(QString::fromLatin1(encoded)));
     QDesktopServices::openUrl(url);
-
-
-    QString html = R"(<html>
-        <head>
-            <meta charset='utf-8'>
-            <link rel='stylesheet' href='https://unpkg.com/leaflet@1.7.1/dist/leaflet.css'/>
-            <script src='https://unpkg.com/leaflet@1.7.1/dist/leaflet.js'></script>
-        </head>
-        <body style='margin:0'>
-        <div id='map' style='width:100%;height:100%'></div>
-        <script>
-            var map = L.map('map').setView([0,0], 2);
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution:'&copy; OpenStreetMap contributors'}).addTo(map);
-            var data = GEOJSON;
-            var layer = L.geoJSON(data).addTo(map);
-            if (layer.getLayers().length)
-                map.fitBounds(layer.getBounds());
-        </script>
-        </body>
-        </html>)";
-
-    html.replace("GEOJSON", geoJson);
-    ui->webViewMap->setHtml(html);
 
 
 }

--- a/travelagencyui.h
+++ b/travelagencyui.h
@@ -19,7 +19,6 @@
 #include <QTableWidgetItem>
 #include <QToolBar>
 #include <QVBoxLayout>
-#include <QWebEngineView>
 #include "customer.h"
 #include "travel.h"
 #include "travelagency.h"

--- a/travelagencyui.ui
+++ b/travelagencyui.ui
@@ -129,16 +129,6 @@
      <string>Buchungen:</string>
     </property>
    </widget>
-   <widget class="QWebEngineView" name="webViewMap">
-    <property name="geometry">
-     <rect>
-      <x>120</x>
-      <y>510</y>
-      <width>411</width>
-      <height>80</height>
-     </rect>
-    </property>
-   </widget>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
   <widget class="QMenuBar" name="menuBar">


### PR DESCRIPTION
## Summary
- implement checkTravelsDisjunct to detect overlapping travels per customer
- use the new check in `Check::performChecks`
- open travel maps with `QDesktopServices::openUrl` only and drop QtWebEngine usage
- clean UI and build files to remove QtWebEngine dependencies

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT" ...)*

------
https://chatgpt.com/codex/tasks/task_e_685b2bb38630832195b9fc0781ba39f1