### PR TITLE
Fix dynamic cast usage and cleanup UI handler

### DIFF
--- a/travelagency.cpp
+++ b/travelagency.cpp
@@ -298,7 +298,7 @@ void TravelAgency::writeFile(const std::string &filename) const
         entry["toDate"] = booking->getToDate().toString("yyyyMMdd").toStdString();
 
         // Buchungstyp-spezifisch ergänzen
-        if (const FlightBooking *fb = dynamic_cast<const FlightBooking *>(booking)) {
+        if (const FlightBooking *fb = dynamic_cast<const FlightBooking *>(booking.get())) {
             entry["type"] = "Flight";
             entry["fromDest"] = fb->getFromDest().toStdString();
             entry["toDest"] = fb->getToDest().toStdString();
@@ -309,7 +309,7 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["toDestLatitude"] = fb->getToLatitude();
             entry["toDestLongitude"] = fb->getToLongitude();
 
-        } else if (const HotelBooking *hb = dynamic_cast<const HotelBooking *>(booking)) {
+        } else if (const HotelBooking *hb = dynamic_cast<const HotelBooking *>(booking.get())) {
             entry["type"] = "Hotel";
             entry["hotel"] = hb->getHotel().toStdString();
             entry["town"] = hb->getTown().toStdString();
@@ -318,7 +318,7 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["longitude"] = hb->getLongitude();
 
         } else if (const RentalCarReservation *rc = dynamic_cast<const RentalCarReservation *>(
-                       booking)) {
+                         booking.get())) {
             entry["type"] = "Rental";
             entry["pickupLocation"] = rc->getPickupLocation().toStdString();
             entry["returnLocation"] = rc->getReturnLocation().toStdString();
@@ -329,7 +329,7 @@ void TravelAgency::writeFile(const std::string &filename) const
             entry["returnLatitude"] = rc->getReturnLatitude();
             entry["returnLongitude"] = rc->getReturnLongitude();
 
-        } else if (const TrainTicket *tt = dynamic_cast<const TrainTicket *>(booking)) {
+        } else if (const TrainTicket *tt = dynamic_cast<const TrainTicket *>(booking.get())) {
             entry["type"] = "Train";
             entry["fromStation"] = tt->getFromStation().toStdString();
             entry["toStation"] = tt->getToStation().toStdString();

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -189,13 +189,13 @@ void TravelAgencyUI::zeigeBuchungenZurReise(std::shared_ptr<Travel> reise)
         ui->customerTable->insertRow(row);
 
         QIcon icon;
-        if (dynamic_cast<FlightBooking *>(b))
+        if (dynamic_cast<FlightBooking *>(b.get()))
             icon = QIcon(":/icons/icons/flug.png");
-        else if (dynamic_cast<HotelBooking *>(b))
+        else if (dynamic_cast<HotelBooking *>(b.get()))
             icon = QIcon(":/icons/icons/hotel.png");
-        else if (dynamic_cast<RentalCarReservation *>(b))
+        else if (dynamic_cast<RentalCarReservation *>(b.get()))
             icon = QIcon(":/icons/icons/auto.png");
-        else if (dynamic_cast<TrainTicket *>(b))
+        else if (dynamic_cast<TrainTicket *>(b.get()))
             icon = QIcon(":/icons/icons/zug.png");
 
 
@@ -244,10 +244,6 @@ void TravelAgencyUI::onCustomerTableDoubleClicked(QTableWidgetItem *item)
             zeigeBuchungenZurReise(currentTravel);
         emit bookingsChanged();
     }
-// Beim Klick auf eine Reise deren Buchungen laden
-
-
-    dlg.exec();
 
 }
 void TravelAgencyUI::onTravelTableDoubleClicked(QTableWidgetItem *item)


### PR DESCRIPTION
## Summary
- fix invalid `dynamic_cast` usage for shared pointers
- remove redundant dialog execution in `TravelAgencyUI`

## Testing
- `cmake ..` *(fails: Could not find Qt configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685b381035608321a15da26abb3d6663