### PR TITLE
Fix duplicate methods and correct URL encoding

### DIFF
--- a/check.h
+++ b/check.h
@@ -14,7 +14,7 @@ public:
     explicit Check(std::shared_ptr<TravelAgency> agency);
     bool checkTravelsDisjunct(QString &errorMsg) const;
     void performChecks() const;
-    void operator()() const { performChecks(); }
+    void operator()() const;
 };
 
 #endif // CHECK_H

--- a/travelagency.cpp
+++ b/travelagency.cpp
@@ -15,7 +15,6 @@
 #include <iomanip>
 #include <iostream>
 #include <set>
-#include <sstream>
 
 using json = nlohmann::json;
 using namespace std;

--- a/travelagency.h
+++ b/travelagency.h
@@ -34,7 +34,7 @@ public:
 
     void loadAirports(const QString &filename);
     const QMap<QString, std::shared_ptr<Airport>> &getAirports() const { return airports; }
-    const std::vector<std::shared_ptr<Booking>> &getBookings() const { return bookings; }
+    const std::vector<std::shared_ptr<Booking>> &getBookings() const;
     QVector<std::shared_ptr<Travel>> getAllTravels() const { return allTravels; }
     QVector<std::shared_ptr<Customer>> getAllCustomers() const { return allCustomers; }
 };

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -385,7 +385,7 @@ void TravelAgencyUI::updateMapForTravel(std::shared_ptr<Travel> travel)
 
     QString encoded = QUrl::toPercentEncoding(geoJson);
     QUrl url(QStringLiteral("https://geojson.io/#data=data:application/json,%1")
-                 .arg(QString::fromLatin1(encoded)));
+                 .arg(QString::fromLatin1(encoded.toLatin1().data())));
     QDesktopServices::openUrl(url);
 
 


### PR DESCRIPTION
## Summary
- remove inline `Check::operator()` definition
- declare `TravelAgency::getBookings` in header and keep cpp definition
- drop unused `<sstream>` include
- fix `QString::fromLatin1` call for encoded URL

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT" with any of the following names: Qt6Config.cmake ...)*

------
https://chatgpt.com/codex/tasks/task_e_685b3d34bb9c83219e3b8b432a79015c