### PR TITLE
Fix QDialogButtonBox include and instantiation

### DIFF
--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -2,6 +2,7 @@
 #include <QFileDialog>
 #include <QFormLayout>
 #include <QLineEdit>
+#include <QDialogButtonBox>
 #include <QMessageBox>
 #include <QIcon>
 #include <QTableWidgetItem>
@@ -139,10 +140,10 @@ bool TravelAgencyUI::showCustomerIdDialog(QString &idOut)
     QLineEdit *input = new QLineEdit;
     layout.addRow("ID:", input);
 
-    QDialogButtonBox buttonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
-    layout.addRow(&buttonBox);
-    connect(&buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
-    connect(&buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    layout.addRow(buttonBox);
+    connect(buttonBox, &QDialogButtonBox::accepted, &dialog, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, &dialog, &QDialog::reject);
 
     if (dialog.exec() == QDialog::Accepted) {
         idOut = input->text().trimmed();


### PR DESCRIPTION
## Summary
- include `<QDialogButtonBox>` header
- create `QDialogButtonBox` on the heap when showing the customer id dialog

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT"...)*

------
https://chatgpt.com/codex/tasks/task_e_685b4d4c8a5c8321bbfd8953f4baff16