### PR TITLE
Add manual data loading buttons

### DIFF
--- a/travelagencyui.h
+++ b/travelagencyui.h
@@ -54,6 +54,8 @@ private slots:
     void on_actionDateiOeffnenClicked();
     void on_actionEintragssucheClicked();
     void on_actionSpeichernTriggered();
+    void on_loadBookingsButton_clicked();
+    void on_loadIataButton_clicked();
     void onCustomerTableDoubleClicked(QTableWidgetItem *item);
     void onTravelTableDoubleClicked(QTableWidgetItem *item);
     void onBookingsChanged();

--- a/travelagencyui.ui
+++ b/travelagencyui.ui
@@ -64,6 +64,32 @@
      </rect>
     </property>
    </widget>
+   <widget class="QPushButton" name="loadBookingsButton">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>20</y>
+      <width>161</width>
+      <height>28</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Buchungen laden</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="loadIataButton">
+    <property name="geometry">
+     <rect>
+      <x>320</x>
+      <y>50</y>
+      <width>161</width>
+      <height>28</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>IATA-Codes laden</string>
+    </property>
+   </widget>
    <widget class="QLabel" name="label">
     <property name="geometry">
      <rect>


### PR DESCRIPTION
## Summary
- remove automatic JSON loading in the main window
- add buttons to load bookings and IATA codes at runtime
- wire up slots for the new buttons

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_685b4edab63c83219aefc232c6dd002e