### PR TITLE
Add booking map display

### DIFF
--- a/bookingdialog.cpp
+++ b/bookingdialog.cpp
@@ -4,6 +4,7 @@
 #include "rentalcarreservation.h"
 #include "trainticket.h"
 #include "travelagency.h"
+#include "travelagencyui.h"
 #include "ui_bookingdialog.h"
 #include <memory>
 
@@ -151,6 +152,9 @@ void BookingDetailDialog::setBooking(std::shared_ptr<Booking> booking)
         ui->listWidgetDetails->clear();
         ui->listWidgetDetails->addItem("Firma: " + car->getCompany());
     }
+
+    if (auto parentUi = qobject_cast<TravelAgencyUI *>(parent()))
+        parentUi->showBookingMap(booking.get());
 }
 
 void BookingDetailDialog::onFieldModified()

--- a/travelagencyui.h
+++ b/travelagencyui.h
@@ -32,6 +32,7 @@ public:
     bool showCustomerIdDialog(QString &idOut);
     void zeigeReisenDesKunden(std::shared_ptr<Customer> kunde);
     void zeigeBuchungenZurReise(std::shared_ptr<Travel> reise);
+    void showBookingMap(const Booking *booking);
 
 private:
     Ui::TravelAgencyUI *ui;


### PR DESCRIPTION
## Summary
- show line map for bookings via new `showBookingMap` in `TravelAgencyUI`
- open the map from `BookingDetailDialog`
- remove previous map call from double click handler

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_685b54d2ff68832185d414b804145c54