### PR TITLE
Revert to file based map geojson

### DIFF
--- a/map.html
+++ b/map.html
@@ -25,13 +25,6 @@ html,body,#map{height:100%;margin:0;padding:0;}
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
-const params = new URLSearchParams(window.location.search);
-let data = null;
-if (params.get('data')) {
-  try {
-    data = JSON.parse(decodeURIComponent(params.get('data')));
-  } catch (e) {}
-}
 
 const map = L.map('map').setView([0, 0], 2);
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
@@ -58,13 +51,9 @@ function showData(geo) {
   }
 }
 
-if (data) {
-  showData(data);
-} else {
-  fetch('map.geojson')
-    .then(r => r.json())
-    .then(showData);
-}
+fetch('map.geojson')
+  .then(r => r.json())
+  .then(showData);
 </script>
 </body>
 </html>

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -436,10 +436,19 @@ void TravelAgencyUI::updateMapForTravel(std::shared_ptr<Travel> travel)
 
     QString geoJson = QString::fromStdString(featureCollection.dump());
 
-    QUrl url = QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
-                                   "/map.html");
-    url.setQuery("data=" + QUrl::toPercentEncoding(geoJson));
-    QDesktopServices::openUrl(url);
+    QString path = QCoreApplication::applicationDirPath() + "/map.geojson";
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(geoJson.toUtf8());
+        file.close();
+    }
+
+    if (QFile::exists(path) && featureCollection["features"].size() > 0) {
+        QUrl url =
+            QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
+                               "/map.html");
+        QDesktopServices::openUrl(url);
+    }
 
 
 }
@@ -497,10 +506,19 @@ void TravelAgencyUI::updateMapForBooking(std::shared_ptr<Booking> booking)
 
     QString geoJson = QString::fromStdString(featureCollection.dump());
 
-    QUrl url = QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
-                                   "/map.html");
-    url.setQuery("data=" + QUrl::toPercentEncoding(geoJson));
-    QDesktopServices::openUrl(url);
+    QString path = QCoreApplication::applicationDirPath() + "/map.geojson";
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(geoJson.toUtf8());
+        file.close();
+    }
+
+    if (QFile::exists(path) && featureCollection["features"].size() > 0) {
+        QUrl url =
+            QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
+                               "/map.html");
+        QDesktopServices::openUrl(url);
+    }
 }
 
 void TravelAgencyUI::showBookingMap(const Booking *booking)
@@ -568,10 +586,19 @@ void TravelAgencyUI::showBookingMap(const Booking *booking)
 
     QString geoJsonStr = QString::fromStdString(featureCollection.dump());
 
-    QUrl url = QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
-                                   "/map.html");
-    url.setQuery("data=" + QUrl::toPercentEncoding(geoJsonStr));
-    QDesktopServices::openUrl(url);
+    QString path = QCoreApplication::applicationDirPath() + "/map.geojson";
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(geoJsonStr.toUtf8());
+        file.close();
+    }
+
+    if (QFile::exists(path) && featureCollection["features"].size() > 0) {
+        QUrl url =
+            QUrl::fromLocalFile(QCoreApplication::applicationDirPath() +
+                               "/map.html");
+        QDesktopServices::openUrl(url);
+    }
 }
 
 void TravelAgencyUI::onBookingsChanged()


### PR DESCRIPTION
## Summary
- generate `map.geojson` before showing any map
- open `map.html` without URL query data
- simplify `map.html` to always load GeoJSON from file

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_685b74045ef08321bddd286a2d91b818