### PR TITLE
Add GeoJSON load error handling

### DIFF
--- a/map.html
+++ b/map.html
@@ -6,6 +6,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <style>
+.message{position:absolute;top:10px;left:50%;transform:translateX(-50%);background:#fff;padding:4px 8px;border:1px solid #ccc;z-index:1000;display:none;}
 html,body,#map{height:100%;margin:0;padding:0;}
 .start-icon,.end-icon{
   display:flex;
@@ -22,11 +23,13 @@ html,body,#map{height:100%;margin:0;padding:0;}
 </style>
 </head>
 <body>
+<div id="message" class="message"></div>
 <div id="map"></div>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script>
 
 const map = L.map('map').setView([0, 0], 2);
+const message = document.getElementById('message');
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   maxZoom: 19,
   attribution: '&copy; OpenStreetMap'
@@ -48,12 +51,29 @@ function showData(geo) {
   }).addTo(map);
   if (layer.getLayers().length) {
     map.fitBounds(layer.getBounds());
+    message.style.display = 'none';
+  } else {
+    message.textContent = 'No map data available.';
+    message.style.display = 'block';
   }
 }
 
 fetch('map.geojson')
-  .then(r => r.json())
-  .then(showData);
+  .catch(err => {
+    console.error('Failed to fetch map.geojson', err);
+    message.textContent = 'Failed to load map data.';
+    message.style.display = 'block';
+  })
+  .then(r => r && r.json().catch(err => {
+    console.error('Failed to parse map.geojson', err);
+    message.textContent = 'Invalid map data.';
+    message.style.display = 'block';
+  }))
+  .then(geo => {
+    if (geo) {
+      showData(geo);
+    }
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add message banner for map errors
- show message when GeoJSON is empty
- add separate catch blocks for fetch and JSON parse

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt package)*

------
https://chatgpt.com/codex/tasks/task_e_685b7799943083219ccd2ebccab75611