### PR TITLE
Install map.html with app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,10 @@ install(TARGETS Praktikum2
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+# Install the map viewer html next to the executable so it can be
+# located at runtime via QCoreApplication::applicationDirPath().
+install(FILES map.html DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(Praktikum2)
 endif()


### PR DESCRIPTION
## Summary
- install `map.html` next to the binary for runtime map display

## Testing
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_685b792b27248321aeab31639b2a7e5b