### PR TITLE
Add map popups and handle zero coordinates

### DIFF
--- a/map.html
+++ b/map.html
@@ -47,6 +47,11 @@ function showData(geo) {
         return L.marker(latlng, {icon: endIcon});
       }
       return L.marker(latlng);
+    },
+    onEachFeature: (feature, l) => {
+      if (feature.properties && feature.properties.name) {
+        l.bindPopup(feature.properties.name);
+      }
     }
   }).addTo(map);
   if (layer.getLayers().length) {
@@ -58,7 +63,8 @@ function showData(geo) {
   }
 }
 
-fetch('map.geojson')
+const geojsonUrl = new URL('map.geojson', window.location.href);
+fetch(geojsonUrl)
   .catch(err => {
     console.error('Failed to fetch map.geojson', err);
     message.textContent = 'Failed to load map data.';

--- a/travelagencyui.cpp
+++ b/travelagencyui.cpp
@@ -385,8 +385,9 @@ void TravelAgencyUI::showMapForBookings(const std::vector<const Booking *> &book
             continue;
 
         if (auto f = dynamic_cast<const FlightBooking *>(b)) {
-            if (f->getFromLatitude() || f->getFromLongitude() || f->getToLatitude()
-                || f->getToLongitude()) {
+            bool validLine = f->getFromLatitude() || f->getFromLongitude()
+                             || f->getToLatitude() || f->getToLongitude();
+            if (validLine) {
                 json line;
                 line["type"] = "Feature";
                 line["geometry"] = {
@@ -397,24 +398,24 @@ void TravelAgencyUI::showMapForBookings(const std::vector<const Booking *> &book
                 };
                 line["properties"] = { {"booking", "flight"} };
                 featureCollection["features"].push_back(line);
-
-                json start;
-                start["type"] = "Feature";
-                start["geometry"] = { {"type", "Point"},
-                                      {"coordinates",
-                                       {f->getFromLongitude(), f->getFromLatitude()}} };
-                start["properties"]
-                    = { {"booking", "flight"}, {"name", "Start"} };
-                featureCollection["features"].push_back(start);
-
-                json end;
-                end["type"] = "Feature";
-                end["geometry"] = { {"type", "Point"},
-                                    {"coordinates",
-                                     {f->getToLongitude(), f->getToLatitude()}} };
-                end["properties"] = { {"booking", "flight"}, {"name", "Ziel"} };
-                featureCollection["features"].push_back(end);
             }
+
+            json start;
+            start["type"] = "Feature";
+            start["geometry"] = { {"type", "Point"},
+                                  {"coordinates",
+                                   {f->getFromLongitude(), f->getFromLatitude()}} };
+            start["properties"]
+                = { {"booking", "flight"}, {"name", "Start"} };
+            featureCollection["features"].push_back(start);
+
+            json end;
+            end["type"] = "Feature";
+            end["geometry"] = { {"type", "Point"},
+                                {"coordinates",
+                                 {f->getToLongitude(), f->getToLatitude()}} };
+            end["properties"] = { {"booking", "flight"}, {"name", "Ziel"} };
+            featureCollection["features"].push_back(end);
         } else if (auto h = dynamic_cast<const HotelBooking *>(b)) {
             json feat;
             feat["type"] = "Feature";


### PR DESCRIPTION
## Summary
- include flight start/end point features even at zero coordinates
- add popups to map markers and use absolute path when fetching `map.geojson`

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "QT")*

------
https://chatgpt.com/codex/tasks/task_e_685b8583a90c832187927928cd9b5c87